### PR TITLE
Release v0.8.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Olena Persianova <olena.persianova@raccoongang.com>
 Valera Rozuvan <valera.rozuvan@gmail.com>
 Vladas Tamoshaitis <amd.vladas@gmail.com>
 Vladimir Ganzii <ganziy.vova@gmail.com>
+Volodymyr Vakulenko <wowkalucky@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,7 +8,8 @@ Alexander Zayats <alexander.zayats@gmail.com>
 Anton Stupak <anton.stupak@raccoongang.com>
 Andrey Doroshenko <dorosshh@gmail.com>
 Dmitry Shyshov <xahgmah@gmail.com>
-Nate Aune <nate@noderabbit.com>
+Nate Aune <nate@appsembler.com>
+Bryan Wilson <bryan@appsembler.com>
 Olena Persianova <olena.persianova@raccoongang.com>
 Valera Rozuvan <valera.rozuvan@gmail.com>
 Vladas Tamoshaitis <amd.vladas@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.1] - 2017-05-18
+
+### Added
+
+- Pass some debugging information to the front end.
+
 ## [0.7.0] - 2017-05-17
 
 ### Added
@@ -186,4 +192,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.6.5]: https://github.com/raccoongang/xblock-video/compare/v0.6.4...v0.6.5
 [0.6.6]: https://github.com/raccoongang/xblock-video/compare/v0.6.5...v0.6.6
 [0.7.0]: https://github.com/raccoongang/xblock-video/compare/v0.6.6...v0.7.0
-[Unreleased]: https://github.com/raccoongang/xblock-video/compare/v0.7.0...HEAD
+[0.7.1]: https://github.com/raccoongang/xblock-video/compare/v0.7.0...v0.7.1
+[Unreleased]: https://github.com/raccoongang/xblock-video/compare/v0.7.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug preventing setting Video Platform API key. E.g. `BC_TOKEN` for Brightcove.
+
 ## [0.7.1] - 2017-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2017-06-30
+
+### Added
+
+- Vimeo: default transcripts fetching.
+
+## Changed
+
+- Use new 3PlayMedia API to fetch transcripts translations.
+- Increase test coverage. Which means better stability.
+
 ### Fixed
 
 - Bug preventing setting Video Platform API key. E.g. `BC_TOKEN` for Brightcove.
+- Transcripts collision bug, which prevented teachers to replace
+  transcript for a given language.
 
 ## [0.7.1] - 2017-05-18
 
@@ -197,4 +210,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.6.6]: https://github.com/raccoongang/xblock-video/compare/v0.6.5...v0.6.6
 [0.7.0]: https://github.com/raccoongang/xblock-video/compare/v0.6.6...v0.7.0
 [0.7.1]: https://github.com/raccoongang/xblock-video/compare/v0.7.0...v0.7.1
-[Unreleased]: https://github.com/raccoongang/xblock-video/compare/v0.7.1...HEAD
+[0.8.0]: https://github.com/raccoongang/xblock-video/compare/v0.7.1...v0.8.0
+[Unreleased]: https://github.com/raccoongang/xblock-video/compare/v0.8.0...HEAD

--- a/README.md
+++ b/README.md
@@ -4,15 +4,10 @@
 [![Coverage Status](https://img.shields.io/codecov/c/github/raccoongang/xblock-video/dev.svg)](https://codecov.io/gh/raccoongang/xblock-video)
 [![GitHub release](https://img.shields.io/github/release/raccoongang/xblock-video.svg)](https://github.com/raccoongang/xblock-video/releases)
 
-XBlock to embed videos hosted on different video platform into your courses.
+The Video XBlock is for embedding videos hosted on different video platforms
+into your Open edX courses.
 
-The idea of crowd-funded universal video-xblock was brought to the
-audience by Nate (Appsembler) on Open edX Con 2016 in Stanford.
-It was well-received and first funds were gathered.
-
-The development was initiated  by Raccoon Gang team, basing on
-previously developed wistia-xblock. Raccoon Gang guys created universal
-pluggable interface and implemented several video-backends:
+Supported video platforms:
 
 - Brightcove
 - Html5
@@ -20,11 +15,31 @@ pluggable interface and implemented several video-backends:
 - Wistia
 - Youtube
 
-Appsembler and Raccoon Gang are presenting the talk on the story of
-video-xblock on Open edX Con 2017 in Madrid.
+The idea of crowd-funded universal video-xblock was proposed by @natea
+(Appsembler) at the Open edX Conference 2016 at Stanford. It was well-received
+and several companies offered to sponsor the initial development.
 
-We welcome open-source community to add more video-backends as well as
-fix issues.
+Appsembler initially contracted with Raccoon Gang to build the [wistia-xblock]
+as a prototype ([see the Github repo]), and later created a new Video XBlock
+featuring universal pluggable interface with several video hosting providers
+support:
+
+[wistia-xblock]: https://appsembler.com/blog/why-open-edx-needs-an-alternative-video-xblock/
+[see the Github repo]: https://github.com/appsembler/xblock-wistia
+
+Appsembler and Raccoon Gang will be co-presenting [a talk about the
+video-xblock] at the Open edX Con 2017 in Madrid.
+
+[a talk about the video-xblock]: https://openedx2017.sched.com/event/9zf6/lightning-talks
+
+We welcome folks from the Open edX community to contribute additional video
+backends as well as report and fix issues.
+
+Thanks to [InterSystems] and [Open University] for sponsoring the initial
+version of the Video XBlock!
+
+[InterSystems]: https://www.intersystems.com
+[Open University]: https://www.open.ac.uk
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ settings:
 
 ## Usage
 
-To embed a video simply copy & paste it's URL into a `Video URL` field.
+To embed a video simply copy & paste its URL into a `Video URL` field.
 
 Sample supported video URLs:
 
@@ -77,13 +77,17 @@ Sample supported video URLs:
 
 ### Brightcove
 
-To successfully use videos hosted on Brightcove Videocloud service one must provide valid Brightcove `account_id` associated with the video. One can find
+To successfully use videos hosted on Brightcove Videocloud service one must
+provide valid Brightcove `account_id` associated with the video. To find out
+your `account_id` go to [Videocloud studio] -> _Admin_ -> _Account Information_.
+
+[Videocloud studio]: https://studio.brightcove.com/products/videocloud/home
 
 #### Connect to Brightcove Platform
 
 1. Grab your [BC_TOKEN] from Brightcove Videocloud.
 1. Open Video XBlock settings, Advanced tab. Scroll down to `Video API Token` section.
-1. Put `BC_TOKENT` taken from Brightcvove into `Client Token` field.
+1. Put `BC_TOKEN` taken from Brightcvove into `Client Token` field.
 1. Click on `Connect to video platform` button.
 
 [BC_TOKEN]: https://docs.brightcove.com/en/video-cloud/media-management/guides/authentication.html

--- a/README.md
+++ b/README.md
@@ -85,11 +85,30 @@ your `account_id` go to [Videocloud studio] -> _Admin_ -> _Account Information_.
 
 #### Connect to Brightcove Platform
 
-1. Grab your [BC_TOKEN] from Brightcove Videocloud.
+1. Grab your [BC_TOKEN] from Brightcove Videocloud:
+   1. Login to [Videocloud Studio] as you normally do.
+   1. With any page in Studio open, open the developer tools for the browser,
+      go to the Console, and paste in the following code:
+
+       ```js
+       var cookiesArray = document.cookie.split(";"), cookiesObj = {}, i, tmpArray = [];
+       for (i = 0; i < cookiesArray.length; i++) {
+           tmpArray = cookiesArray[i].split("=");
+           if (tmpArray[0].indexOf('BC_TOKEN') > -1) {
+               cookiesObj.BC_TOKEN = tmpArray[1];
+           }
+       }
+       window.prompt("BC_TOKEN:", cookiesObj.BC_TOKEN);
+       ```
+
+      and press `<return>`.
+   1. You should see a prompt appear that contains your BC_TOKEN.
+    ![BC_TOKEN sample](https://learning-services-media.brightcove.com/doc-assets/video-cloud-apis/ingest-profiles-api/guides/prompt-with-token-safari.png "Sample BC_TOKEN")
 1. Open Video XBlock settings, Advanced tab. Scroll down to `Video API Token` section.
 1. Put `BC_TOKEN` taken from Brightcvove into `Client Token` field.
 1. Click on `Connect to video platform` button.
 
+[Videocloud Studio]: https://studio.brightcove.com/products/videocloud/home
 [BC_TOKEN]: https://docs.brightcove.com/en/video-cloud/media-management/guides/authentication.html
 
 #### Enable content encryption and/or autoquality

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,4 @@
 dependencies:
-  pre:
-    - sudo apt-get update; sudo apt-get install python-lxml
   override:
     - nvm install stable && npm install
     - make tools

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,22 @@
 """Setup for video XBlock."""
 
 import os
+import re
 from setuptools import setup
 
 
-VERSION = '0.6.5'
-DESCRIPTION = 'Video XBlock to embed videos hosted on different video platforms into your courseware'
+def get_version(*file_paths):
+    """
+    Extract the version string from the file at the given relative path fragments.
+    """
+    filename = os.path.join(os.path.dirname(__file__), *file_paths)
+    version_file = open(filename).read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError('Unable to find version string.')
 
 
 def package_data(pkg, roots):
@@ -22,6 +33,10 @@ def package_data(pkg, roots):
                 data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
 
     return {pkg: data}
+
+
+VERSION = get_version('video_xblock', '__init__.py')
+DESCRIPTION = 'Video XBlock to embed videos hosted on different video platforms into your courseware'
 
 
 setup(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-bok-choy==0.7.0
+bok-choy==0.7.1
 coverage>=4.3.4,<5.0.0
 Django>=1.8.12,<1.9
 ddt>=1.1.1,<2.0.0

--- a/video_xblock/__init__.py
+++ b/video_xblock/__init__.py
@@ -2,4 +2,7 @@
 Video xblock module.
 """
 
-from .video_xblock import *  # pylint: disable=wildcard-import
+__version__ = '0.7.1'
+
+# pylint: disable=wildcard-import
+from .video_xblock import *  # nopep8

--- a/video_xblock/__init__.py
+++ b/video_xblock/__init__.py
@@ -2,7 +2,7 @@
 Video xblock module.
 """
 
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 
 # pylint: disable=wildcard-import
 from .video_xblock import *  # nopep8

--- a/video_xblock/backends/base.py
+++ b/video_xblock/backends/base.py
@@ -155,6 +155,13 @@ class BaseVideoPlayer(Plugin):
         """
         return self.xblock.download_video_url
 
+    @property
+    def default_transcripts_in_vtt(self):
+        """
+        Return: (bool) if default transcripts fetched already in VTT format.
+        """
+        return False
+
     def get_frag(self, **context):
         """
         Return a Fragment required to render video player on the client side.

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -7,14 +7,18 @@ import base64
 from datetime import datetime
 import json
 import httplib
+import logging
 import re
 
 import requests
 from xblock.fragment import Fragment
 
 from video_xblock.backends.base import BaseVideoPlayer, BaseApiClient
+from video_xblock.constants import TranscriptSource
 from video_xblock.exceptions import ApiClientError, VideoXBlockException
 from video_xblock.utils import ugettext as _, remove_escaping
+
+log = logging.getLogger(__name__)
 
 
 class BrightcoveApiClientError(ApiClientError):
@@ -525,6 +529,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
                 ]
             message (str): Message for a user with details on default transcripts fetching outcomes.
         """
+        log.debug("BC: getting default transcripts...")
         if not self.api_key and not self.api_secret:
             raise BrightcoveApiClientError(_('No API credentials provided'))
 
@@ -532,40 +537,38 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
         account_id = kwargs.get('account_id')
         url = self.captions_api['url'].format(account_id=account_id, media_id=video_id)
         message = ''
-        self.default_transcripts = []
+        default_transcripts = []
         # Fetch available transcripts' languages and urls if authentication succeeded.
         try:
             text = self.api_client.get(url)
         except BrightcoveApiClientError:
-            message = 'No timed transcript may be fetched from a video platform.'
-            return self.default_transcripts, message
+            message = _('No timed transcript may be fetched from a video platform.')
+            return default_transcripts, message
 
-        if text:
-            captions_data = text.get('text_tracks')
-            # Handle empty response (no subs uploaded on a platform)
-            if not captions_data:
-                message = 'For now, video platform doesn\'t have any timed transcript for this video.'
-                return self.default_transcripts, message
-            transcripts_data = [
-                [el.get('src'), el.get('srclang')]
-                for el in captions_data
-            ]
-            # Populate default_transcripts
-            for transcript_url, lang_code in transcripts_data:
-                lang_label = self.get_transcript_language_parameters(lang_code)[1]
-                self.default_transcripts.append({
-                    'lang': lang_code,
-                    'label': lang_label,
-                    'url': transcript_url,
-                })
-        else:
-            try:
-                # no way this code could be executed
-                # TODO: refactor this code
-                message = str(text[0].get('message'))
-            except AttributeError:
-                message = 'No timed transcript may be fetched from a video platform.'
-        return self.default_transcripts, message
+        if not text:
+            message = _('No timed transcript may be fetched from a video platform.')
+            return default_transcripts, message
+
+        # Handle empty response (no subs uploaded on a platform)
+        captions_data = text.get('text_tracks')
+
+        if not captions_data:
+            message = _("For now, video platform doesn't have any timed transcript for this video.")
+            return default_transcripts, message
+
+        # Populate default_transcripts
+        transcripts_data = ([cap_data.get('src'), cap_data.get('srclang')] for cap_data in captions_data)
+
+        for transcript_url, lang_code in transcripts_data:
+            lang_label = self.get_transcript_language_parameters(lang_code)[1]
+            default_transcripts.append({
+                'lang': lang_code,
+                'label': lang_label,
+                'url': transcript_url,
+                'source': TranscriptSource.DEFAULT,
+            })
+        log.debug("BC: default transcripts: {}".format(default_transcripts))
+        return default_transcripts, message
 
     def download_default_transcript(self, url=None, language_code=None):  # pylint: disable=unused-argument
         """
@@ -576,6 +579,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
         Returns:
             sub (unicode): Transcripts formatted per WebVTT format https://w3c.github.io/webvtt/
         """
+        log.debug("BC: downloading default transcript from url:{}".format(url))
         if url is None:
             raise VideoXBlockException(_('`url` parameter is required.'))
         data = requests.get(url)

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -8,14 +8,13 @@ from datetime import datetime
 import json
 import httplib
 import re
-from xml.sax.saxutils import unescape
 
 import requests
 from xblock.fragment import Fragment
 
 from video_xblock.backends.base import BaseVideoPlayer, BaseApiClient
 from video_xblock.exceptions import ApiClientError, VideoXBlockException
-from video_xblock.utils import ugettext as _
+from video_xblock.utils import ugettext as _, remove_escaping
 
 
 class BrightcoveApiClientError(ApiClientError):
@@ -339,7 +338,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
     @property
     def advanced_fields(self):
         """
-        Tuple of VideoXBlock fields to display in Basic tab of edit modal window.
+        Tuple of VideoXBlock fields to display in Advanced tab of edit modal window.
 
         Brightcove videos require Brightcove Account id.
         """
@@ -581,16 +580,5 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
             raise VideoXBlockException(_('`url` parameter is required.'))
         data = requests.get(url)
         text = data.content.decode('utf8')
-        # To clean subs text from special symbols here, we need `unescape()` from xml.sax.saxutils
-        # Reference: https://wiki.python.org/moin/EscapingHtml
-        html_unescape_table = {
-            "&amp;": "&",
-            "&quot;": '"',
-            "&amp;#39;": "'",
-            "&apos;": "'",
-            "&gt;": ">",
-            "&lt;": "<"
-        }
-        unescaped_text = unescape(text, html_unescape_table)
-        sub = unicode(unescaped_text)
-        return sub
+        cleaned_captions_text = remove_escaping(text)
+        return unicode(cleaned_captions_text)

--- a/video_xblock/backends/vimeo.py
+++ b/video_xblock/backends/vimeo.py
@@ -1,10 +1,72 @@
 # -*- coding: utf-8 -*-
-"""Vimeo Video player plugin."""
+"""
+Vimeo Video player plugin.
+"""
 
+import httplib
 import json
+import logging
 import re
 
-from video_xblock import BaseVideoPlayer
+import requests
+
+from video_xblock import BaseVideoPlayer, ApiClientError
+from video_xblock.backends.base import BaseApiClient
+from video_xblock.utils import ugettext as _, remove_escaping
+
+log = logging.getLogger(__name__)
+
+
+class VimeoApiClientError(ApiClientError):
+    """
+    Vimeo specific api client errors.
+    """
+
+    default_msg = _('Vimeo API error.')
+
+
+class VimeoApiClient(BaseApiClient):
+    """
+    Low level Vimeo API client.
+
+    Does all heavy lifting of sending https requests over the wire.
+    Responsible for API credentials issuing and access_token refreshing.
+    """
+
+    def __init__(self, token=None):
+        """
+        Initialize Vimeo API client.
+        """
+        self.access_token = token or ''
+
+    def get(self, url, headers=None, can_retry=False):
+        """
+        Issue REST GET request to a given URL. Can throw ApiClientError or its subclass.
+
+        Arguments:
+            url (str): API url to fetch a resource from.
+            headers (dict): Headers necessary as per API, e.g. authorization bearer to perform
+            authorised requests.
+        Returns:
+            Response in python native data format.
+        """
+        headers_ = {
+            'Authorization': 'Bearer {}'.format(self.access_token),
+            'Accept': 'application/json'
+        }
+        if headers is not None:
+            headers_.update(headers)
+        resp = requests.get(url, headers=headers_)
+        if resp.status_code == httplib.OK:
+            return resp.json()
+        else:
+            raise VimeoApiClientError(_("Can't fetch requested data from API."))
+
+    def post(self, url, payload, headers=None, can_retry=False):
+        """
+        Issue REST POST request to a given URL. Can throw ApiClientError or its subclass.
+        """
+        raise VimeoApiClientError(_('Advanced API operations not allowed for now.'))
 
 
 class VimeoPlayer(BaseVideoPlayer):
@@ -16,10 +78,68 @@ class VimeoPlayer(BaseVideoPlayer):
     # Reference: https://vimeo.com/153979733
     url_re = re.compile(r'https?:\/\/(.+)?(vimeo.com)\/(?P<media_id>.*)')
 
-    metadata_fields = []
+    metadata_fields = ['access_token']
+    default_transcripts_in_vtt = True
 
-    # Vimeo API for requesting transcripts.
-    captions_api = {}
+    # Current Vimeo api for requesting transcripts.
+
+    # Note: Vimeo will automatically delete tokens that have not been used for an extended period of time.
+    #       If your API calls are months apart you might need to create a new token.
+
+    # For example: GET https://api.vimeo.com/videos/204151304/texttracks
+    # Docs on captions: https://developer.vimeo.com/api/endpoints/videos#/%7Bvideo_id%7D/texttracks
+    # Docs on auth: https://developer.vimeo.com/api/authentication
+    captions_api = {
+        'url': 'https://api.vimeo.com/videos/{media_id}/texttracks',
+        'authorised_request_header': {
+            'Authorization': 'Bearer {access_token}'
+        },
+        'response': {
+            'total': '{transcripts_count}',
+            'data': [
+                {
+                    'uri': '/texttracks/{transcript_id}',
+                    'active': 'true',
+                    'type': 'subtitles',
+                    'language': 'en',  # no language_label translated in English may be fetched from API
+                    'link': 'https://{link_to_vtt_file}',
+                    'link_expires_time': 1497954324,
+                    'hls_link': 'https://{link_to_vtt_file_with_hls}',
+                    'hls_link_expires_time': 1497954324,
+                    'name': '{captions_file_name.vtt}'
+                }
+            ]
+        }
+    }
+
+    def __init__(self, xblock):
+        """
+        Initialize Vimeo player class object.
+        """
+        super(VimeoPlayer, self).__init__(xblock)
+        self.api_client = VimeoApiClient(token=xblock.token)
+
+    @property
+    def advanced_fields(self):
+        """
+        Tuple of VideoXBlock fields to display in Advanced tab of edit modal window.
+
+        Vimeo videos require Access token to be set.
+        """
+        fields_list = super(VimeoPlayer, self).advanced_fields
+        # Add `token` field before `threeplaymedia_file_id`
+        fields_list.insert(fields_list.index('threeplaymedia_file_id'), 'token')
+        return fields_list
+
+    fields_help = {
+        'href': _('URL of the video page. E.g. https://vimeo.com/987654321'),
+        'token': _(
+            'You can generate a Vimeo access token via <b>Application console\'s Authentication section</b> by '
+            '<a href="https://developer.vimeo.com/apps/new" '
+            'target="_blank">creating new app</a>. Please ensure appropriate operations '
+            'scope ("private") has been set for access token.'
+        )
+    }
 
     def media_id(self, href):
         """
@@ -66,3 +186,88 @@ class VimeoPlayer(BaseVideoPlayer):
             "vimeo": {"iv_load_policy": 1},
         })
         return result
+
+    def get_default_transcripts(self, **kwargs):
+        """
+        Fetch transcripts list from a video platform.
+
+        Arguments:
+            kwargs (dict): Key-value pairs with video_id, fetched from video xblock,
+                           and access_token for Vimeo API.
+        Returns:
+            default_transcripts (list): list of dicts of transcripts. Example:
+                [
+                    {
+                        'lang': 'en',
+                        'label': 'English',
+                        'url': 'captions.cloud.vimeo.com/captions/{transcript_id}.vtt?expires=1497970668&sig=
+                                {signature_hash}&download={file_name.vtt}"'
+                    },
+                    # ...
+                ]
+            message (str): Message for a user with details on default transcripts fetching outcomes.
+        """
+        if not self.api_client.access_token:
+            raise VimeoApiClientError(_('No API credentials provided.'))
+
+        video_id = kwargs.get('video_id')
+        url = self.captions_api['url'].format(media_id=video_id)
+        message = _('Default transcripts successfully fetched from a video platform.')
+        default_transcripts = []
+        # Fetch available transcripts' languages and urls.
+        try:
+            json_data = self.api_client.get(url)
+        except VimeoApiClientError:
+            message = _('No timed transcript may be fetched from a video platform.')
+            return default_transcripts, message
+
+        if not json_data:
+            message = _('There are no default transcripts for the video on the video platform.')
+            return default_transcripts, message
+
+        # Populate default_transcripts
+        transcripts_data = json_data.get('data')
+        try:
+            default_transcripts = self.parse_vimeo_texttracks(transcripts_data)
+            return default_transcripts, message
+        except VimeoApiClientError as client_exc:
+            message = client_exc.message
+            return default_transcripts, message
+
+    def parse_vimeo_texttracks(self, transcripts_data):
+        """
+        Pull from texttracks' Vimeo API response json_data language and url information.
+
+        Arguments:
+            transcripts_data (list of dicts): Transcripts data.
+        Returns:
+            transcript (dict): {language code, language label, download url}
+        """
+        default_transcripts = []
+        for t_data in transcripts_data:
+            try:
+                lang_code = t_data["language"]
+                lang_label = self.get_transcript_language_parameters(lang_code)[1]
+                default_transcripts.append({
+                    'lang': lang_code,
+                    'label': lang_label,
+                    'url': t_data["link"],
+                })
+            except KeyError:
+                raise VimeoApiClientError(_('Transcripts API has been changed.'))
+        log.debug("Parsed Vimeo transcripts: " + str(default_transcripts))
+        return default_transcripts
+
+    def download_default_transcript(self, url, language_code=None):  # pylint: disable=unused-argument
+        """
+        Download default transcript from Vimeo video platform API in WebVVT format.
+
+        Arguments:
+            url (str): Transcript download url.
+        Returns:
+            sub (unicode): Transcripts formatted per WebVTT format https://w3c.github.io/webvtt/
+        """
+        data = requests.get(url)
+        text = data.content.decode('utf8')
+        cleaned_captions_text = remove_escaping(text)
+        return unicode(cleaned_captions_text)

--- a/video_xblock/backends/wistia.py
+++ b/video_xblock/backends/wistia.py
@@ -12,6 +12,7 @@ import requests
 import babelfish
 
 from video_xblock import BaseVideoPlayer
+from video_xblock.constants import TranscriptSource
 from video_xblock.utils import ugettext as _
 from video_xblock.exceptions import VideoXBlockException
 
@@ -206,6 +207,7 @@ class WistiaPlayer(BaseVideoPlayer):
                         'label': lang_label,
                         'url': '',
                         'text': text,
+                        'source': TranscriptSource.DEFAULT,
                     })
             # If captions do not exist for a video, the response will be an empty JSON array.
             # Reference: https://wistia.com/doc/data-api#captions_index

--- a/video_xblock/backends/youtube.py
+++ b/video_xblock/backends/youtube.py
@@ -13,8 +13,9 @@ import urllib
 import requests
 from lxml import etree
 
-from video_xblock.utils import ugettext as _
+from video_xblock.constants import TranscriptSource
 from video_xblock.exceptions import VideoXBlockException
+from video_xblock.utils import ugettext as _
 
 from .base import BaseVideoPlayer
 
@@ -158,6 +159,7 @@ class YoutubePlayer(BaseVideoPlayer):
                 'lang': lang_code,
                 'label': lang_label,
                 'url': transcript_url,
+                'source': TranscriptSource.DEFAULT,
             })
         return self.default_transcripts, message
 

--- a/video_xblock/constants.py
+++ b/video_xblock/constants.py
@@ -18,6 +18,25 @@ class PlayerName(object):
     YOUTUBE = 'youtube-player'
 
 
+class TranscriptSource(object):
+    """
+    Define transcript source, e.g. where transcript was fetched from.
+    """
+
+    DEFAULT = 'default'
+    MANUAL = 'manual'
+    THREE_PLAY_MEDIA = '3play-media'
+
+    ALL = ['DEFAULT', 'MANUAL', 'THREE_PLAY_MEDIA']
+
+    @classmethod
+    def to_dict(cls):
+        """
+        Make dict of available sources.
+        """
+        return {k: getattr(cls, k) for k in cls.ALL}
+
+
 class TPMApiTranscriptFormatID(object):
     """
     3PlayMedia service's transcripts API format_name - format_ID mapping.

--- a/video_xblock/constants.py
+++ b/video_xblock/constants.py
@@ -2,7 +2,6 @@
 Lists of constants that can be used in the video xblock.
 """
 
-
 DEFAULT_LANG = 'en'
 
 
@@ -17,3 +16,265 @@ class PlayerName(object):
     VIMEO = 'vimeo-player'
     WISTIA = 'wistia-player'
     YOUTUBE = 'youtube-player'
+
+
+class TPMApiTranscriptFormatID(object):
+    """
+    3PlayMedia service's transcripts API format_name - format_ID mapping.
+
+    Full list can be got by GET to "http://static.3playmedia.com/output_formats?apikey=foo".
+    """
+
+    SRT = 7
+    JSON = 29
+    PDF = 46
+    WEBVTT = 51
+
+
+class TPMApiLanguage(object):
+    """
+    3PlayMedia service's transcripts API language_ID - language info (e.g.: code, name...) mapping.
+
+    Full list can be got by GET to "http://api.3playmedia.com/caption_imports/available_languages?apikey=:api_key"
+    """
+
+    TPM_LANGUAGES = {
+        1: {
+            "ietf_code": "en",
+            "iso_639_1_code": "en",
+            "name": "English",
+            "full_name": "English",
+        },
+        3: {
+            "ietf_code": "en",
+            "iso_639_1_code": "en",
+            "name": "English",
+            "full_name": "English (GB)",
+        },
+        5: {
+            "ietf_code": "fr",
+            "iso_639_1_code": "fr",
+            "name": "French",
+            "full_name": "French (France)",
+        },
+        6: {
+            "ietf_code": "fr",
+            "iso_639_1_code": "fr",
+            "name": "French",
+            "full_name": "French (Canada)",
+        },
+        7: {
+            "ietf_code": "de",
+            "iso_639_1_code": "de",
+            "name": "German",
+            "full_name": "German",
+        },
+        8: {
+            "ietf_code": "it",
+            "iso_639_1_code": "it",
+            "name": "Italian",
+            "full_name": "Italian",
+        },
+        9: {
+            "ietf_code": "nl",
+            "iso_639_1_code": "nl",
+            "name": "Dutch",
+            "full_name": "Dutch",
+        },
+        10: {
+            "ietf_code": "el",
+            "iso_639_1_code": "el",
+            "name": "Greek",
+            "full_name": "Greek",
+        },
+        12: {
+            "ietf_code": "es",
+            "iso_639_1_code": "es",
+            "name": "Spanish",
+            "full_name": "Spanish (Spain)",
+        },
+        13: {
+            "ietf_code": "es-419",
+            "iso_639_1_code": "es",
+            "name": "Spanish",
+            "full_name": "Spanish (Latin America)",
+        },
+        15: {
+            "ietf_code": "pt",
+            "iso_639_1_code": "pt",
+            "name": "Portuguese",
+            "full_name": "Portuguese (Portugal)",
+        },
+        16: {
+            "ietf_code": "pt",
+            "iso_639_1_code": "pt",
+            "name": "Portuguese",
+            "full_name": "Portuguese (Brazil)",
+        },
+        18: {
+            "ietf_code": "zh-hans",
+            "iso_639_1_code": "zh",
+            "name": "Chinese",
+            "full_name": "Chinese (Simplified)",
+        },
+        19: {
+            "ietf_code": "zh-cmn-Hant",
+            "iso_639_1_code": "zh",
+            "name": "Chinese",
+            "full_name": "Chinese (Traditional)",
+        },
+        20: {
+            "ietf_code": "ar",
+            "iso_639_1_code": "ar",
+            "name": "Arabic",
+            "full_name": "Arabic",
+        },
+        21: {
+            "ietf_code": "he",
+            "iso_639_1_code": "he",
+            "name": "Hebrew",
+            "full_name": "Hebrew",
+        },
+        22: {
+            "ietf_code": "ru",
+            "iso_639_1_code": "ru",
+            "name": "Russian",
+            "full_name": "Russian",
+        },
+        23: {
+            "ietf_code": "ja",
+            "iso_639_1_code": "ja",
+            "name": "Japanese",
+            "full_name": "Japanese",
+        },
+        26: {
+            "ietf_code": "",
+            "iso_639_1_code": "sv",
+            "name": "Swedish",
+            "full_name": "Swedish",
+        },
+        27: {
+            "ietf_code": "",
+            "iso_639_1_code": "cs",
+            "name": "Czech",
+            "full_name": "Czech",
+        },
+        28: {
+            "ietf_code": "",
+            "iso_639_1_code": "da",
+            "name": "Danish",
+            "full_name": "Danish",
+        },
+        29: {
+            "ietf_code": "",
+            "iso_639_1_code": "fi",
+            "name": "Finnish",
+            "full_name": "Finnish",
+        },
+        30: {
+            "ietf_code": "",
+            "iso_639_1_code": "id",
+            "name": "Indonesian",
+            "full_name": "Indonesian",
+        },
+        31: {
+            "ietf_code": "",
+            "iso_639_1_code": "ko",
+            "name": "Korean",
+            "full_name": "Korean",
+        },
+        32: {
+            "ietf_code": "",
+            "iso_639_1_code": "no",
+            "name": "Norwegian",
+            "full_name": "Norwegian",
+        },
+        33: {
+            "ietf_code": "",
+            "iso_639_1_code": "pl",
+            "name": "Polish",
+            "full_name": "Polish",
+        },
+        34: {
+            "ietf_code": "",
+            "iso_639_1_code": "th",
+            "name": "Thai",
+            "full_name": "Thai",
+        },
+        35: {
+            "ietf_code": "",
+            "iso_639_1_code": "tr",
+            "name": "Turkish",
+            "full_name": "Turkish",
+        },
+        36: {
+            "ietf_code": "",
+            "iso_639_1_code": "vi",
+            "name": "Vietnamese",
+            "full_name": "Vietnamese",
+        },
+        37: {
+            "ietf_code": "",
+            "iso_639_1_code": "ro",
+            "name": "Romanian",
+            "full_name": "Romanian",
+        },
+        38: {
+            "ietf_code": "",
+            "iso_639_1_code": "hu",
+            "name": "Hungarian",
+            "full_name": "Hungarian",
+        },
+        39: {
+            "ietf_code": "",
+            "iso_639_1_code": "ms",
+            "name": "Malay",
+            "full_name": "Malay",
+        },
+        40: {
+            "ietf_code": "",
+            "iso_639_1_code": "bg",
+            "name": "Bulgarian",
+            "full_name": "Bulgarian",
+        },
+        41: {
+            "ietf_code": "",
+            "iso_639_1_code": "tl",
+            "name": "Tagalog",
+            "full_name": "Tagalog",
+        },
+        46: {
+            "ietf_code": "",
+            "iso_639_1_code": "sr",
+            "name": "Serbian",
+            "full_name": "Serbian",
+        },
+        47: {
+            "ietf_code": "",
+            "iso_639_1_code": "sk",
+            "name": "Slovak",
+            "full_name": "Slovak",
+        },
+        48: {
+            "ietf_code": "",
+            "iso_639_1_code": "uk",
+            "name": "Ukrainian",
+            "full_name": "Ukrainian",
+        }
+    }
+
+    def __init__(self, language_id):
+        """
+        Initiate 3PlayMedia language information based on given language ID.
+
+        :param language_id : int (from API response list of available transcript translations).
+        """
+        if language_id not in self.TPM_LANGUAGES.keys():
+            raise ValueError("Language ID: {} does not exist!".format(language_id))
+        language_info = self.TPM_LANGUAGES[language_id]
+        self.language_id = language_id
+        self.ietf_code = language_info.get("ietf_code")
+        self.iso_639_1_code = language_info.get("iso_639_1_code")
+        self.name = language_info.get("name")
+        self.full_name = language_info.get("full_name")
+        self.description = language_info.get("description")

--- a/video_xblock/static/html/student_view.html
+++ b/video_xblock/static/html/student_view.html
@@ -35,3 +35,6 @@
     {% endif %}
 </ul>
 
+<div id="xblock-info" class="is-hidden">
+    Version: {{ version }}
+</div>

--- a/video_xblock/static/html/studio-edit-default-transcripts.html
+++ b/video_xblock/static/html/studio-edit-default-transcripts.html
@@ -12,7 +12,7 @@
       <div class="custom-field-section-label enabled-transcripts">{% trans "Enabled transcripts" %}</div>
       {% if transcripts  %}
       <!-- Display a list of transcripts fetched from a video xblock -->
-        {% for transcript in transcripts %}
+        {% for transcript in enabled_default_transcripts %}
           <div class="enabled-default-transcripts-section">
             <div class="default-transcripts-label" value="{{ transcript.lang }}">
               {{ transcript.label }}
@@ -63,6 +63,7 @@
                  data-change-field-name="{{ field.name }}"
                  data-lang-code="{{ default_transcript.lang }}"
                  data-lang-label="{{ default_transcript.label }}"
+                 data-source="{{ default_transcript.source }}"
                  data-download-url="{{ default_transcript.url }}" >
                 {% trans "Upload" %}
               </a>
@@ -70,7 +71,7 @@
           </div>
           <div class="api-response upload-default-transcript {{ default_transcript.lang }} status"></div>
         {% endfor %}
-        {% for transcript in transcripts %}
+        {% for transcript in enabled_default_transcripts %}
           <!-- Success message of enabled transcript removal is to be displayed. -->
           <div class="api-response remove-default-transcript {{ transcripts.lang }} status"></div>
         {% endfor %}

--- a/video_xblock/static/html/studio-edit-token.html
+++ b/video_xblock/static/html/studio-edit-token.html
@@ -1,17 +1,25 @@
 {% load i18n %}
 
 <div class="custom-field-list">
-  <div class="custom-field-section-label">{% trans "Client Token" %}</div>
+  <div class="custom-field-section-label">
+    {% if player_name == players.VIMEO %}
+      {% trans "Application Access Token" %}
+    {% else %}
+      {% trans "Client Token" %}
+    {% endif %}
+  </div>
   <input
     type="text"
     class="field-data-control token"
     id="xb-field-edit-{{field.name}}"
     value="{{field.value|default_if_none:''}}"
   >
-  <div class="field-elements-wrapper">
-    <button id="video-api-authenticate">
-      <span aria-hidden="true"></span>{% trans "Connect to video platform" %}<span class="sr"></span>
-    </button>
-  </div>
+  {% ifequal player_name players.BRIGHTCOVE %}
+    <div class="field-elements-wrapper">
+      <button id="video-api-authenticate">
+        <span aria-hidden="true"></span>{% trans "Connect to video platform" %}<span class="sr"></span>
+      </button>
+    </div>
+  {% endifequal %}
   <div class="api-response authenticate status"></div>
 </div>

--- a/video_xblock/static/html/studio-edit-transcripts.html
+++ b/video_xblock/static/html/studio-edit-transcripts.html
@@ -41,6 +41,8 @@
     </a>
 </div>
 
-<form method="POST" action="/assets/{{ courseKey }}/" class="file-uploader-form is-hidden" enctype="multipart/form-data">
-  <input class="input-file-uploader" name="file" type="file" accept="" data-change-field-name="" data-lang-code="" data-lang-label="">
+<form method="POST" action="/assets/{{ courseKey }}/" class="file-uploader-form is-hidden"
+      enctype="multipart/form-data">
+  <input class="input-file-uploader" name="file" type="file" accept="" data-change-field-name="" data-lang-code=""
+         data-lang-label="" {% for source in sources %}data-source-{{ source.0 }}="{{ source.1 }}" {% endfor %}>
 </form>

--- a/video_xblock/static/js/studio-edit/studio-edit.js
+++ b/video_xblock/static/js/studio-edit/studio-edit.js
@@ -215,15 +215,17 @@ function StudioEditableXBlock(runtime, element) {
             var newLang = response.lang;
             var newLabel = response.label;
             var newUrl = response.url;
+            var source = response.source;
             // Add a default transcript to the list of enabled ones
             var downloadUrl = runtimeHandlers.downloadTranscript + '?' + newUrl;
             var defaultTranscript = {
                 lang: newLang,
                 label: newLabel,
-                url: downloadUrl
+                url: downloadUrl,
+                source: source
             };
             // Create a standard transcript
-            pushTranscript(newLang, newLabel, newUrl, '', transcriptsValue);
+            pushTranscript(newLang, newLabel, newUrl, source, '', transcriptsValue);
             pushTranscriptsValue(transcriptsValue);
             createEnabledTranscriptBlock(defaultTranscript, downloadUrl);
             bindRemovalListenerEnabledTranscript(newLang, newLabel, newUrl);
@@ -258,7 +260,8 @@ function StudioEditableXBlock(runtime, element) {
             var defaultTranscript = {
                 lang: langCode,
                 label: langLabel,
-                url: downloadUrlApi
+                url: downloadUrlApi,
+                source: $fileUploader.data('source-default')
             };
             uploadDefaultTranscriptsToServer(defaultTranscript);
             // Affect standard transcripts
@@ -405,7 +408,7 @@ function StudioEditableXBlock(runtime, element) {
      * Get transcripts from 3playmedia's API and show result message.
      */
     function getTranscripts3playmediaApi(data) {
-        var message, status, includeLang;
+        var message, status;
         var options = {
             type: 'POST',
             url: runtimeHandlers.getTranscripts3playmediaApi,
@@ -419,15 +422,9 @@ function StudioEditableXBlock(runtime, element) {
             var successMessage = response.success_message;
             if (successMessage && response.transcripts) {
                 response.transcripts.forEach(function(item) {
-                    includeLang = transcriptsValue.find(function(element) { // eslint-disable-line no-shadow
-                        return element.lang === item.lang;
-                    });
-                    // Add a transcript from the 3playmedia only for non exists language
-                    if (!includeLang) {
-                        createTranscriptBlock(item.lang, item.label, transcriptsValue, item.url);
-                        pushTranscript(item.lang, item.label, item.url, '', transcriptsValue);
-                        pushTranscriptsValue(transcriptsValue);
-                    }
+                    createTranscriptBlock(item.lang, item.label, transcriptsValue, item.url);
+                    pushTranscript(item.lang, item.label, item.url, item.source, '', transcriptsValue);
+                    pushTranscriptsValue(transcriptsValue);
                 });
             }
 
@@ -520,6 +517,7 @@ function StudioEditableXBlock(runtime, element) {
         var downloadUrlServer;
         var defaultTranscript;
         var isValidated = validateTranscriptFile(event, fieldName, filename, $fileUploader);
+        var source = $fileUploader.data('source-manual');
         if (fieldName === 'handout' && isValidated) {
             $parentDiv = $('.file-uploader');
             $('.download-setting', $parentDiv).attr('href', downloadUrl).removeClass('is-hidden');
@@ -527,7 +525,7 @@ function StudioEditableXBlock(runtime, element) {
             showStatus($('.status', $parentDiv), SUCCESS, successMessage);
             $('input[data-field-name=' + fieldName + ']').val(url).change();
         } else if (fieldName === 'transcripts' && isValidated) {
-            pushTranscript(lang, label, url, '', transcriptsValue);
+            pushTranscript(lang, label, url, source, '', transcriptsValue);
             $('.add-transcript').removeClass('is-disabled');
             $('input[data-field-name=' + fieldName + ']').val(JSON.stringify(transcriptsValue)).change();
             $(currentLiTag).find('.upload-transcript').text('Replace');
@@ -665,10 +663,12 @@ function StudioEditableXBlock(runtime, element) {
         var langCode = $currentTarget.attr('data-lang-code');
         var label = $currentTarget.attr('data-lang-label');
         var url = $currentTarget.attr('data-download-url');
+        var source = $currentTarget.attr('data-source');
         var defaultTranscript = {
             lang: langCode,
             label: label,
-            url: url
+            url: url,
+            source: source
         };
         event.preventDefault();
         event.stopPropagation();

--- a/video_xblock/static/js/studio-edit/transcripts-manual-upload.js
+++ b/video_xblock/static/js/studio-edit/transcripts-manual-upload.js
@@ -127,10 +127,11 @@ function validateTranscriptFile(event, fieldName, filename, $fileUploader) {
  * @param {String} lang
  * @param {String} label
  * @param {String} url
+ * @param {String} source
  * @param {String} oldLang
  * @param {Array} transcriptsValue
  */
-function pushTranscript(lang, label, url, oldLang, transcriptsValue) {
+function pushTranscript(lang, label, url, source, oldLang, transcriptsValue) {
     'use strict';
     var indexLanguage;
     var i;
@@ -143,6 +144,7 @@ function pushTranscript(lang, label, url, oldLang, transcriptsValue) {
     if (indexLanguage !== undefined) {
         transcriptsValue[indexLanguage].lang = lang;  // eslint-disable-line no-param-reassign
         transcriptsValue[indexLanguage].label = label;  // eslint-disable-line no-param-reassign
+        transcriptsValue[indexLanguage].source = source;  // eslint-disable-line no-param-reassign
         if (url) {
             transcriptsValue[indexLanguage].url = url;  // eslint-disable-line no-param-reassign
         }
@@ -151,7 +153,8 @@ function pushTranscript(lang, label, url, oldLang, transcriptsValue) {
         transcriptsValue.push({
             lang: lang,
             url: url,
-            label: label
+            label: label,
+            source: source
         });
         return true;
     }
@@ -267,10 +270,11 @@ function languageChecker(event, transcriptsValue, disabledLanguages) {
     var $langSelectParent = $(event.currentTarget).parent('li');
     var $uploadButton = $('.upload-transcript', $langSelectParent);
     var oldLang = $uploadButton.data('lang-code');
+    var source = $('.input-file-uploader').data('source-manual');
     var newTranscriptAdded;
     event.stopPropagation();
     if (selectedLanguage !== oldLang && selectedLanguage !== '') {
-        newTranscriptAdded = pushTranscript(selectedLanguage, languageLabel, '', oldLang, transcriptsValue);
+        newTranscriptAdded = pushTranscript(selectedLanguage, languageLabel, '', source, oldLang, transcriptsValue);
         if (newTranscriptAdded) {
             $uploadButton.removeClass('is-hidden');
         }

--- a/video_xblock/tests/unit/mocks/base.py
+++ b/video_xblock/tests/unit/mocks/base.py
@@ -48,6 +48,12 @@ class ResponseStub(object):
             except KeyError:
                 pass
 
+    def json(self):
+        """
+        Make response compatible with requests.Response.
+        """
+        return getattr(self, 'body', '')
+
 
 class BaseMock(Mock):
     """

--- a/video_xblock/tests/unit/mocks/brightcove.py
+++ b/video_xblock/tests/unit/mocks/brightcove.py
@@ -74,8 +74,8 @@ class BrightcoveDefaultTranscriptsMock(BaseMock):
     """
 
     _default_transcripts = [
-        {'label': u'English', 'lang': u'en', 'url': None},
-        {'label': u'Ukrainian', 'lang': u'uk', 'url': None}
+        {'label': u'English', 'lang': u'en', 'url': None, 'source': u'default'},
+        {'label': u'Ukrainian', 'lang': u'uk', 'url': None, 'source': u'default'}
     ]
 
     _response = {

--- a/video_xblock/tests/unit/mocks/youtube.py
+++ b/video_xblock/tests/unit/mocks/youtube.py
@@ -27,9 +27,9 @@ class YoutubeDefaultTranscriptsMock(BaseMock):
     ]
 
     _default_transcripts = [
-        {'label': u'English', 'lang': u'en',
+        {'label': u'English', 'lang': u'en', 'source': u'default',
          'url': 'http://video.google.com/timedtext?lang=en&name=&v=set_video_id_here'},
-        {'label': u'Ukrainian', 'lang': u'uk',
+        {'label': u'Ukrainian', 'lang': u'uk', 'source': u'default',
          'url': 'http://video.google.com/timedtext?lang=uk&name=&v=set_video_id_here'}
     ]
 

--- a/video_xblock/tests/unit/test_constants.py
+++ b/video_xblock/tests/unit/test_constants.py
@@ -1,0 +1,42 @@
+"""
+Test cases for constants entities.
+"""
+
+import unittest
+
+from ddt import ddt, data
+from video_xblock.constants import TPMApiLanguage
+
+
+@ddt
+class ConstantsTest(unittest.TestCase):
+    """
+    Test Constants.
+    """
+
+    def test_three_play_media_language_data_constant_creation(self):
+        """Test 3PlayMedia available transcript language_info object creation"""
+        self.assertRaises(ValueError, TPMApiLanguage, 'a')
+        self.assertRaises(ValueError, TPMApiLanguage, 999)
+
+    @data({
+        1: {
+            "ietf_code": "en",
+            "iso_639_1_code": "en",
+            "name": "English",
+            "full_name": "English",
+        },
+        48: {
+            "ietf_code": "",
+            "iso_639_1_code": "uk",
+            "name": "Ukrainian",
+            "full_name": "Ukrainian",
+        }
+    })
+    def test_three_play_media_language_data_constant_structure(self, test_data):
+        """Test 3PlayMedia available transcript language_info object creation"""
+        for lang_id, lang_info in test_data.items():
+            self.assertEqual(TPMApiLanguage(lang_id).ietf_code, lang_info["ietf_code"])
+            self.assertEqual(TPMApiLanguage(lang_id).iso_639_1_code, lang_info["iso_639_1_code"])
+            self.assertEqual(TPMApiLanguage(lang_id).name, lang_info["name"])
+            self.assertEqual(TPMApiLanguage(lang_id).full_name, lang_info["full_name"])

--- a/video_xblock/tests/unit/test_mixins.py
+++ b/video_xblock/tests/unit/test_mixins.py
@@ -403,7 +403,7 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         request_get_mock.has_calls([call(vtt_translation_url), call(all_transcripts_url)])
 
         create_transcript_file_mock.assert_called_once_with(
-            reference_name="English_captions_video_" + media_id_mock.return_value,
+            reference_name="English_3play-media_captions_video_" + media_id_mock.return_value,
             trans_str=vtt_file_mock.return_value
         )
         self.assertEquals(status, 'success')

--- a/video_xblock/tests/unit/test_utils.py
+++ b/video_xblock/tests/unit/test_utils.py
@@ -21,7 +21,9 @@ class UtilsTest(unittest.TestCase):
         'long_test_variable': 'longTestVariable'
     })
     def test_underscore_to_mixedcase(self, test_data):
-        """Test string conversion from underscore to mixedcase"""
+        """
+        Test string conversion from underscore to mixedcase
+        """
         for string, expected_result in test_data.items():
             self.assertEqual(underscore_to_mixedcase(string), expected_result)
 

--- a/video_xblock/tests/unit/test_video_xblock.py
+++ b/video_xblock/tests/unit/test_video_xblock.py
@@ -186,10 +186,12 @@ class VideoXBlockTests(VideoXBlockTestBase):
             'courseKey': 'course_key',
             'default_transcripts': self.xblock.default_transcripts,
             'download_transcript_handler_url': handler_url_mock.return_value,
+            'enabled_default_transcripts': [],
             'initial_default_transcripts': ['stub1', 'stub2'],
             'languages': [{'code': 'en', 'label': 'English'}],
             'player_name': self.xblock.player_name,
             'players': PlayerName,
+            'sources': [('DEFAULT', 'default'), ('THREE_PLAY_MEDIA', '3play-media'), ('MANUAL', 'manual')],
             'transcripts': [],
             'transcripts_autoupload_message': 'Stub autoupload messate',
         }

--- a/video_xblock/tests/unit/test_video_xblock.py
+++ b/video_xblock/tests/unit/test_video_xblock.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from web_fragments.fragment import FragmentResource
 from xblock.fragment import Fragment
 
-from video_xblock import VideoXBlock
+from video_xblock import VideoXBlock, __version__
 from video_xblock.constants import PlayerName
 from video_xblock.utils import ugettext as _
 from video_xblock.tests.unit.base import VideoXBlockTestBase
@@ -134,7 +134,8 @@ class VideoXBlockTests(VideoXBlockTestBase):
             player_url='/player/url',
             transcript_download_link='/transcript/download/url'+'/transcript/link.vtt',
             transcripts='transcripts.vtt',
-            usage_id='usage_id'
+            usage_id='usage_id',
+            version=__version__,
         )
         resource_string_mock.assert_called_with('static/css/student-view.css')
         handler_url.assert_called_with(self.xblock, 'download_transcript')

--- a/video_xblock/tests/unit/test_video_xblock.py
+++ b/video_xblock/tests/unit/test_video_xblock.py
@@ -188,6 +188,8 @@ class VideoXBlockTests(VideoXBlockTestBase):
             'download_transcript_handler_url': handler_url_mock.return_value,
             'initial_default_transcripts': ['stub1', 'stub2'],
             'languages': [{'code': 'en', 'label': 'English'}],
+            'player_name': self.xblock.player_name,
+            'players': PlayerName,
             'transcripts': [],
             'transcripts_autoupload_message': 'Stub autoupload messate',
         }

--- a/video_xblock/tests/unit/test_video_xblock.py
+++ b/video_xblock/tests/unit/test_video_xblock.py
@@ -23,30 +23,34 @@ class VideoXBlockTests(VideoXBlockTestBase):
     Test cases for video_xblock.
     """
 
-    def test_fields_xblock(self):
+    def test_xblock_fields_default_values(self):
         """
         Test xblock fields consistency with their default values.
         """
 
-        self.assertEqual(self.xblock.display_name, _('Video'))
-        self.assertEqual(self.xblock.href, '')
         self.assertEqual(self.xblock.account_id, 'account_id')
-        self.assertEqual(self.xblock.player_id, 'default')
-        self.assertEqual(self.xblock.player_name, PlayerName.DUMMY)
-        self.assertEqual(self.xblock.start_time, datetime.timedelta(seconds=0))
-        self.assertEqual(self.xblock.end_time, datetime.timedelta(seconds=0))
-        self.assertEqual(self.xblock.current_time, 0)
-        self.assertEqual(self.xblock.playback_rate, 1)
-        self.assertEqual(self.xblock.volume, 1)
-        self.assertEqual(self.xblock.muted, False)
-        self.assertEqual(self.xblock.captions_language, '')
-        self.assertEqual(self.xblock.transcripts_enabled, False)
         self.assertEqual(self.xblock.captions_enabled, False)
-        self.assertEqual(self.xblock.handout, '')
-        self.assertEqual(self.xblock.transcripts, '')
+        self.assertEqual(self.xblock.captions_language, '')
+        self.assertEqual(self.xblock.current_time, 0)
+        self.assertEqual(self.xblock.default_transcripts, '')
+        self.assertEqual(self.xblock.display_name, _('Video'))
         self.assertEqual(self.xblock.download_transcript_allowed, False)
         self.assertEqual(self.xblock.download_video_allowed, False)
         self.assertEqual(self.xblock.download_video_url, '')
+        self.assertEqual(self.xblock.end_time, datetime.timedelta(seconds=0))
+        self.assertEqual(self.xblock.handout, '')
+        self.assertEqual(self.xblock.href, '')
+        self.assertEqual(self.xblock.muted, False)
+        self.assertEqual(self.xblock.playback_rate, 1)
+        self.assertEqual(self.xblock.player_id, 'default')
+        self.assertEqual(self.xblock.player_name, PlayerName.DUMMY)
+        self.assertEqual(self.xblock.start_time, datetime.timedelta(seconds=0))
+        self.assertEqual(self.xblock.threeplaymedia_apikey, 'default')
+        self.assertEqual(self.xblock.threeplaymedia_file_id, 'default')
+        self.assertEqual(self.xblock.token, '')
+        self.assertEqual(self.xblock.transcripts, '')
+        self.assertEqual(self.xblock.transcripts_enabled, False)
+        self.assertEqual(self.xblock.volume, 1)
 
     def test_get_brightcove_js_url(self):
         """
@@ -157,7 +161,6 @@ class VideoXBlockTests(VideoXBlockTestBase):
         unused_context_stub = object()
         all_languages_mock.__iter__.return_value = [['en', 'English']]
         self.xblock.runtime.handler_url = handler_url_mock = Mock()
-        authenticate_video_api_mock.return_value = (object(), 'Stub auth error message')
         update_default_transcripts_mock.return_value = (
             ['stub1', 'stub2'], 'Stub autoupload messate'
         )
@@ -178,7 +181,7 @@ class VideoXBlockTests(VideoXBlockTestBase):
 
         expected_context = {
             'advanced_fields': advanced_fields_stub,
-            'auth_error_message': 'Stub auth error message',
+            'auth_error_message': '',
             'basic_fields': basic_fields_stub,
             'courseKey': 'course_key',
             'default_transcripts': self.xblock.default_transcripts,
@@ -196,6 +199,7 @@ class VideoXBlockTests(VideoXBlockTestBase):
         render_template_mock.assert_called_once_with('studio-edit.html', **expected_context)
         handler_url_mock.assert_called_with(self.xblock, 'download_transcript')
         update_default_transcripts_mock.assert_called_once()
+        authenticate_video_api_mock.assert_not_called()
 
     @staticmethod
     def _make_fragment_resource(file_name):

--- a/video_xblock/tests/unit/test_video_xblock_handlers.py
+++ b/video_xblock/tests/unit/test_video_xblock_handlers.py
@@ -3,7 +3,8 @@ Test cases for VideoXBlock handlers
 """
 
 import json
-from mock import patch, Mock
+
+from mock import patch, Mock, PropertyMock
 
 from video_xblock import VideoXBlock
 from video_xblock.tests.unit.base import VideoXBlockTestBase
@@ -40,3 +41,58 @@ class AuthenticateApiHandlerTests(VideoXBlockTestBase):
             json.dumps({'success_message': 'Successfully authenticated to the video platform.'})
         )
         auth_video_api_mock.assert_called_once_with('test-token-123')  # Python string
+
+
+class UploadDefaultTranscriptHandlerTests(VideoXBlockTestBase):
+    """
+    Test cases for `VideoXBlock.upload_default_transcript_handler`
+    """
+
+    @patch('video_xblock.video_xblock.create_reference_name')
+    def test_upload_handler_default_transcript_not_in_vtt_case(self, create_reference_name_mock):
+        # Arrange
+        request_body = """{"label": "test_label","lang": "test_lang","source": "test_source","url": "test_url"}"""
+        assert_data = json.loads(request_body)
+        test_media_id = 'test_video_id'
+        test_subs_text = 'test_subs_text'
+        test_reference = 'test_reference'
+        test_file_name = 'test_file_name'
+        test_external_url = 'test_external_url'
+
+        request_mock = arrange_request_mock(request_body)
+        create_reference_name_mock.return_value = test_reference
+
+        with patch.object(self.xblock, 'get_player') as get_player_mock, \
+                patch.object(self.xblock, 'convert_caps_to_vtt') as convert_caps_mock, \
+                patch.object(self.xblock, 'create_transcript_file') as create_transcript_file_mock:
+
+            get_player_mock.return_value = player_mock = Mock()
+            convert_caps_mock.return_value = prepared_subs_mock = Mock()
+            create_transcript_file_mock.return_value = (test_file_name, test_external_url)
+
+            player_mock.media_id.return_value = test_media_id
+            player_mock.download_default_transcript.return_value = test_subs_text
+            type(player_mock).default_transcripts_in_vtt = PropertyMock(return_value=False)
+
+        # Act
+            response = self.xblock.upload_default_transcript_handler(request_mock)
+        # Assert
+            player_mock.download_default_transcript.assert_called_with(
+                url=assert_data['url'], language_code=assert_data['lang']
+            )
+            create_reference_name_mock.assert_called_with(assert_data['label'], test_media_id, assert_data['source'])
+            player_mock.download_default_transcript.assert_called_with(
+                url=assert_data['url'], language_code=assert_data['lang']
+            )
+            convert_caps_mock.assert_called_with(caps=test_subs_text)
+            create_transcript_file_mock.assert_called_with(trans_str=prepared_subs_mock, reference_name=test_reference)
+            self.assertEqual(
+                response.body,  # pylint: disable=no-member
+                json.dumps({
+                    'success_message': 'Successfully uploaded "test_file_name".',
+                    'lang': assert_data['lang'],
+                    'url': test_external_url,
+                    'label': assert_data['label'],
+                    'source': assert_data['source'],
+                })
+            )

--- a/video_xblock/tests/unit/test_video_xblock_handlers.py
+++ b/video_xblock/tests/unit/test_video_xblock_handlers.py
@@ -1,0 +1,42 @@
+"""
+Test cases for VideoXBlock handlers
+"""
+
+import json
+from mock import patch, Mock
+
+from video_xblock import VideoXBlock
+from video_xblock.tests.unit.base import VideoXBlockTestBase
+
+
+def arrange_request_mock(request_body):
+    """
+    Helper factory to create request mocks
+    """
+    request_mock = Mock()
+    request_mock.method = 'POST'
+    request_mock.body = request_body
+    return request_mock
+
+
+class AuthenticateApiHandlerTests(VideoXBlockTestBase):
+    """
+    Test cases for `VideoXBlock.authenticate_video_api_handler`
+    """
+
+    @patch.object(VideoXBlock, 'authenticate_video_api')
+    def test_auth_video_api_handler_delegates_call(self, auth_video_api_mock):
+        # Arrange
+        request_mock = arrange_request_mock('"test-token-123"')  # JSON string
+        auth_video_api_mock.return_value = {}, ''
+
+        # Act
+        result_response = self.xblock.authenticate_video_api_handler(request_mock)
+        result = result_response.body  # pylint: disable=no-member
+
+        # Assert
+        self.assertEqual(
+            result,
+            json.dumps({'success_message': 'Successfully authenticated to the video platform.'})
+        )
+        auth_video_api_mock.assert_called_once_with('test-token-123')  # Python string

--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -5,11 +5,13 @@ Video xblock helpers.
 from HTMLParser import HTMLParser
 from importlib import import_module
 from xml.sax.saxutils import unescape
-
 import os.path
 import pkg_resources
+
 from django.template import Engine, Context, Template
 from xblockutils.resources import ResourceLoader
+
+from .constants import TranscriptSource
 
 html_parser = HTMLParser()  # pylint: disable=invalid-name
 loader = ResourceLoader(__name__)  # pylint: disable=invalid-name
@@ -93,3 +95,35 @@ def remove_escaping(text):
         "&lt;": "<"
     }
     return unescape(text, html_unescape_table)
+
+
+def create_reference_name(lang_label, video_id, source="default"):
+    """
+    Build transcript file reference based on input information.
+
+    Format is <language label>_<source>_captions_video_<video_id>, e.g. "English_default_captions_video_456g68"
+    """
+    reference = "{lang_label}_{source}_captions_video_{video_id}".format(
+        lang_label=lang_label,
+        video_id=video_id,
+        source=source,
+    ).encode('utf8')
+    return reference
+
+
+def filter_transcripts_by_source(transcripts, source=TranscriptSource.DEFAULT):
+    """
+    Filter given transcripts by source attribute.
+    """
+    if not transcripts:
+        return transcripts
+    return (tr for tr in transcripts if tr['source'] == source)
+
+
+def normalize_transcripts(transcripts):
+    """
+    Add to manually uploaded transcripts "source" attribute.
+    """
+    for tr_dict in transcripts:
+        tr_dict.setdefault('source', TranscriptSource.MANUAL)
+    return transcripts

--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -4,12 +4,12 @@ Video xblock helpers.
 
 from HTMLParser import HTMLParser
 from importlib import import_module
+from xml.sax.saxutils import unescape
+
 import os.path
 import pkg_resources
-
 from django.template import Engine, Context, Template
 from xblockutils.resources import ResourceLoader
-
 
 html_parser = HTMLParser()  # pylint: disable=invalid-name
 loader = ResourceLoader(__name__)  # pylint: disable=invalid-name
@@ -76,3 +76,20 @@ def underscore_to_mixedcase(value):
 
     mix = mixedcase()
     return "".join(mix.next()(x) if x else '_' for x in value.split("_"))
+
+
+def remove_escaping(text):
+    """
+    Clean text from special `escape` symbols.
+
+    Reference: https://wiki.python.org/moin/EscapingHtml.
+    """
+    html_unescape_table = {
+        "&amp;": "&",
+        "&quot;": '"',
+        "&amp;#39;": "'",
+        "&apos;": "'",
+        "&gt;": ">",
+        "&lt;": "<"
+    }
+    return unescape(text, html_unescape_table)

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -39,7 +39,7 @@ class VideoXBlock(
     """
     Main VideoXBlock class, responsible for saving video settings and rendering it for students.
 
-    VideoXBlock only provide a storage falicities for fields data, but not
+    VideoXBlock only provide a storage facilities for fields data, but not
     decide what fields to show to user. `BaseVideoPlayer` and it's subclassess
     declare what fields are required for proper configuration of a video.
     See `BaseVideoPlayer.basic_fields` and `BaseVideoPlayer.advanced_fields`.

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -27,6 +27,7 @@ from .workbench.mixin import WorkbenchMixin
 from .settings import ALL_LANGUAGES
 from .fields import RelativeTime
 from .utils import render_template, render_resource, resource_string, ugettext as _
+from . import __version__
 
 log = logging.getLogger(__name__)
 
@@ -317,7 +318,8 @@ class VideoXBlock(
                 download_transcript_allowed=self.download_transcript_allowed,
                 download_video_url=self.get_download_video_url(),
                 handout_file_name=self.get_file_name_from_path(self.handout),
-                transcript_download_link=full_transcript_download_link
+                transcript_download_link=full_transcript_download_link,
+                version=__version__,
             )
         )
         frag.add_javascript(resource_string("static/js/student-view/video-xblock.js"))

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -642,7 +642,7 @@ class VideoXBlock(
         response = Response(json.dumps(resp), content_type='application/json')
         return response
 
-    def authenticate_video_api(self, token=''):
+    def authenticate_video_api(self, token):
         """
         Authenticate to a video platform's API.
 
@@ -654,10 +654,7 @@ class VideoXBlock(
         """
         # TODO move auth fields validation and kwargs population to specific backends
         # Handles a case where no token was provided by a user
-        if token:
-            kwargs = {'token': token}
-        else:
-            kwargs = {'token': self.token}
+        kwargs = {'token': token}
 
         # Handles a case where no account_id was provided by a user
         if str(self.player_name) == PlayerName.BRIGHTCOVE:
@@ -667,9 +664,7 @@ class VideoXBlock(
             kwargs['account_id'] = self.account_id
 
         player = self.get_player()
-        if str(self.player_name) == PlayerName.BRIGHTCOVE and not self.metadata.get('client_id'):
-            auth_data, error_message = player.authenticate_api(**kwargs)
-        elif str(self.player_name) == PlayerName.BRIGHTCOVE and self.metadata.get('client_id'):
+        if str(self.player_name) == PlayerName.BRIGHTCOVE and self.metadata.get('client_id'):
             auth_data = {
                 'client_secret': self.metadata.get('client_secret'),
                 'client_id': self.metadata.get('client_id'),
@@ -694,10 +689,7 @@ class VideoXBlock(
             response (dict): Status messages key-value pairs.
         """
         # Fetch a token provided by a user before the save button was clicked.
-        if str(data) != self.token:
-            token = str(data)
-        else:
-            token = ''
+        token = str(data)
 
         is_default_token = token == self.fields['token'].default  # pylint: disable=unsubscriptable-object
         is_youtube_player = str(self.player_name) != PlayerName.YOUTUBE  # pylint: disable=unsubscriptable-object


### PR DESCRIPTION
## [0.8.0] - 2017-06-30

### Added

- Vimeo: default transcripts fetching.

## Changed

- Use new 3PlayMedia API to fetch transcripts translations.
- Increase test coverage. Which means better stability.

### Fixed

- Bug preventing setting Video Platform API key. E.g. `BC_TOKEN` for Brightcove.
- Transcripts collision bug, which prevented teachers to replace
  transcript for a given language.

## [0.7.1] - 2017-05-18

### Added

- Pass some debugging information to the front end.

## Minor changes

- Reintegrate changes in the README.md made by @natea 
- Address minor issues in Usage documentation.
- Pass some debugging information to the front end.
