### PR TITLE
tox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Python package
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python-version: 3.8
+            tox-env: quality
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install virtualenv tox tox-pip-version
+      - name: "Run tox targets for ${{ matrix.python-version }}"
+        run: "tox -e ${{ matrix.tox-env }}"

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'video_xblock',
     ],
     dependency_links=[
-         # Replace dependency links with numbered versions when it's released on PyPI
+        # Replace dependency links with numbered versions when it's released on PyPI
         'git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5',
     ],
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py3
+
+[testenv]
+deps =
+    -rtest_requirements.txt
+commands =
+    nosetests video_xblock.tests.unit
+
+[testenv:quality]
+commands =
+    pycodestyle . --format=pylint --max-line-length=120
+    pydocstyle
+    pylint -f colorized video_xblock
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py3,quality
 
 [testenv]
 deps =
@@ -10,6 +10,6 @@ commands =
 [testenv:quality]
 commands =
     pycodestyle . --format=pylint --max-line-length=120
-    pydocstyle
-    pylint -f colorized video_xblock
+    # pydocstyle
+    # pylint -f colorized video_xblock
 

--- a/video_xblock/backends/youtube.py
+++ b/video_xblock/backends/youtube.py
@@ -8,7 +8,9 @@ import json
 import http.client as httplib
 import re
 import textwrap
-import urllib.request, urllib.parse, urllib.error
+import urllib.error
+import urllib.parse
+import urllib.request
 
 import requests
 from lxml import etree

--- a/video_xblock/exceptions.py
+++ b/video_xblock/exceptions.py
@@ -2,8 +2,6 @@
 Custom, VideoXblock specific Exceptions.
 """
 
-
-
 from .utils import ugettext as _
 
 

--- a/video_xblock/tests/unit/test_video_xblock.py
+++ b/video_xblock/tests/unit/test_video_xblock.py
@@ -205,7 +205,7 @@ class VideoXBlockTests(VideoXBlockTestBase):
             'languages': [{'code': 'en', 'label': 'English'}],
             'player_name': self.xblock.player_name,
             'players': PlayerName,
-            'sources': list({'DEFAULT' : 'default', 'MANUAL': 'manual', 'THREE_PLAY_MEDIA': '3play-media'}.items()),
+            'sources': list({'DEFAULT': 'default', 'MANUAL': 'manual', 'THREE_PLAY_MEDIA': '3play-media'}.items()),
             'three_pm_fields': three_pm_fields_stub,
             'transcripts': [],
             'transcripts_fields': transcripts_fields_stub,


### PR DESCRIPTION
The project's existing `Makefile` has a bunch of testing targets. I ported the basic python tests and the python quality tests to tox.

Added a workflow to run tox on PRs.

The python tests are currently failing:

```
$ tox -e py3
GLOB sdist-make: /home/anders/work/xblock-video/setup.py
py3 inst-nodeps: /home/anders/work/xblock-video/.tox/.tmp/package/1/video-xblock-1.0.2.zip
py3 installed: appdirs==1.4.4,astroid==2.10.0,babelfish==0.5.5,beautifulsoup4==4.8.2,bok-choy==0.7.1,certifi==2021.10.8,charset-normalizer==2.0.12,click==8.0.4,click-log==0.3.2,coverage==4.5.4,cssutils==2.4.0,ddt==1.4.4,Django==2.2.25,edx-lint==1.5.2,fs==2.4.15,future==0.18.2,idna==3.3,isort==4.3.21,lazy==1.4,lazy-object-proxy==1.7.1,le-pycaption==2.2.0a1,lxml==4.8.0,Mako==1.1.6,MarkupSafe==2.1.0,mccabe==0.6.1,mock==2.0.0,needle==0.5.0,nose==1.3.7,pbr==5.8.1,Pillow==9.0.1,pycodestyle==2.6.0,pydocstyle==5.1.1,pylint==2.4.4,pylint-celery==0.3,pylint-django==2.0.11,pylint-plugin-utils==0.7,python-dateutil==2.8.2,pytz==2021.3,PyYAML==6.0,requests==2.27.1,selenium==3.141.0,simplejson==3.17.6,six==1.16.0,snowballstemmer==2.2.0,soupsieve==2.3.1,sqlparse==0.4.2,typing-extensions==4.1.1,urllib3==1.26.8,video-xblock @ file:///home/anders/work/xblock-video/.tox/.tmp/package/1/video-xblock-1.0.2.zip,web-fragments==2.0.0,WebOb==1.8.7,wrapt==1.13.3,XBlock==1.3.1,-e git+https://github.com/edx/xblock-sdk.git@8d3956c81f63d102e50d759feb47deff4ad814a4#egg=xblock_sdk,xblock-utils==2.1.1
py3 run-test-pre: PYTHONHASHSEED='2257366583'
py3 run-test: commands[0] | nosetests video_xblock.tests.unit
.......................................................................................F...........................................................
======================================================================
FAIL: Test xBlock's `usage_id` property works properly.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/anders/work/xblock-video/video_xblock/tests/unit/test_mixins.py", line 136, in test_usage_id
    self.assertEqual(self.xblock.usage_id, 'test_str')
AssertionError: "<Mock id='140204972800560'>" != 'test_str'
- <Mock id='140204972800560'>
+ test_str


----------------------------------------------------------------------
Ran 147 tests in 10.408s

FAILED (failures=1)
ERROR: InvocationError for command /home/anders/work/xblock-video/.tox/py3/bin/nosetests video_xblock.tests.unit (exited with code 1)
________________________________________________________________________ summary _________________________________________________________________________
ERROR:   py3: commands failed
```

That will need to be fixed before we can enable the python tests on PRs. So for now, it just runs the `quality` test, which is effectively just `pycodestyle`. Not much, but it's a start.